### PR TITLE
Added remote.connect_to_ip configuration feature

### DIFF
--- a/raveloxmidi/include/dns_service_discover.h
+++ b/raveloxmidi/include/dns_service_discover.h
@@ -30,6 +30,7 @@ typedef struct dns_service_t {
 int dns_discover_services( int use_ipv4, int use_ipv6 );
 void dns_discover_add( const char *name, char *address, int port );
 dns_service_t *dns_discover_by_name( const char *name );
+dns_service_t *set_fixed_ip( const char *ip );
 void dns_discover_free_services( void );
 void dns_discover_init( void );
 void dns_discover_teardown( void );

--- a/raveloxmidi/src/dns_service_discover.c
+++ b/raveloxmidi/src/dns_service_discover.c
@@ -181,6 +181,17 @@ fail:
 
 dns_service_t *dns_discover_by_name( const char *name )
 {
+
+  //just to test
+  dns_service_t * my_server;
+  my_server = (dns_service_t *)malloc( sizeof( dns_service_t ) );
+	my_server->name = (char *)strdup( "landev" );
+	my_server->ip_address = ( char *)strdup( "192.168.179.138" );
+  my_server->port = 5004;
+
+  return my_server;
+
+
 	int i = 0;
 
 	if( num_services < 1 ) return NULL;

--- a/raveloxmidi/src/dns_service_discover.c
+++ b/raveloxmidi/src/dns_service_discover.c
@@ -179,18 +179,20 @@ fail:
     return num_services;
 }
 
-dns_service_t *dns_discover_by_name( const char *name )
+dns_service_t *set_fixed_ip( const char *ip )
 {
-
-  //just to test
   dns_service_t * my_server;
   my_server = (dns_service_t *)malloc( sizeof( dns_service_t ) );
 	my_server->name = (char *)strdup( "landev" );
-	my_server->ip_address = ( char *)strdup( "192.168.179.138" );
+	my_server->ip_address = ( char *)strdup( ip );
   my_server->port = 5004;
 
   return my_server;
 
+}
+
+dns_service_t *dns_discover_by_name( const char *name )
+{
 
 	int i = 0;
 

--- a/raveloxmidi/src/raveloxmidi.c
+++ b/raveloxmidi/src/raveloxmidi.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 	} else {
 		net_socket_loop_init();
 
-		if( config_string_get("remote.connect") )
+		if( config_string_get("remote.connect") || config_string_get("remote.connect_to_ip") )
 		{
 			dns_discover_init();
 			remote_connect_init();

--- a/raveloxmidi/src/remote_connection.c
+++ b/raveloxmidi/src/remote_connection.c
@@ -62,18 +62,29 @@ void remote_connect_init( void )
 {
 	dns_service_t *found_service = NULL;
 	char *remote_service_name = NULL;
+  char *remote_service_ip = NULL;
 	char *client_name = NULL;
 	net_response_t *response = NULL;
 	net_ctx_t *ctx;
 	int use_ipv4, use_ipv6;
 	uint32_t initiator = 0, ssrc = 0;
+  int fixedIP = 0;
 
 	remote_service_name = config_string_get("remote.connect");
+  remote_service_ip = config_string_get("remote.connect_to_ip");
 
 	if( (! remote_service_name)  || ( strlen( remote_service_name ) <=0 ) )
 	{
 		logging_printf(LOGGING_WARN, "remote_connect_init: remote.connect option is present but not set\n");
-		return;
+    if( (! remote_service_ip)  || ( strlen( remote_service_ip ) <=0 ) )
+    {
+      logging_printf(LOGGING_WARN, "remote_connect_init: remote.connect option is present but not set\n");
+		  return;
+    }
+    else
+    {
+      fixedIP = 1;
+    }
 	}
 
 	logging_printf(LOGGING_DEBUG, "remote_connect_init: Looking for [%s]\n", remote_service_name);
@@ -83,11 +94,15 @@ void remote_connect_init( void )
 
 	if( dns_discover_services( use_ipv4, use_ipv6 ) <= 0 )
 	{
-		logging_printf(LOGGING_WARN, "remote_connect_init: No services available\n");
-		//return;  //just a test
+		logging_printf(LOGGING_WARN, "remote_connect_init: No services found in Local Network\n");
+    if (fixedIP == 0)
+		  return;
 	}
 
-	found_service = dns_discover_by_name( remote_service_name );
+  if (fixedIP = 0)
+  	found_service = dns_discover_by_name( remote_service_name );
+  else
+    found_service = set_fixed_ip( remote_service_ip );
 
 	if( ! found_service )
 	{

--- a/raveloxmidi/src/remote_connection.c
+++ b/raveloxmidi/src/remote_connection.c
@@ -84,7 +84,7 @@ void remote_connect_init( void )
 	if( dns_discover_services( use_ipv4, use_ipv6 ) <= 0 )
 	{
 		logging_printf(LOGGING_WARN, "remote_connect_init: No services available\n");
-		return;
+		//return;  //just a test
 	}
 
 	found_service = dns_discover_by_name( remote_service_name );


### PR DESCRIPTION
Hello Dave

i added the Feature, I called it *remote.connect_to_ip* but you can rename if you don't like.

I'm not a C Programmer but as far as I can say it should be OK that, maybe the function
*dns_service_t *set_fixed_ip( const char *ip )*
should be in a different place, maybe not.

with kind regards
Marc

UPDATE: I just tried the modified version over the Internet over different ISP's and it worked with quite good and low Latency. Of course you need to open the Ports 5004 && 5005 on the Firewall (NAT/PAT/FW) on that side that plays the "Server" but not on both, the client can even be on a Double-NAT and it still works.