### PR TITLE
Keep separate running status for each file descriptor

### DIFF
--- a/raveloxmidi/include/midi_payload.h
+++ b/raveloxmidi/include/midi_payload.h
@@ -58,10 +58,10 @@ void midi_payload_unset_j( midi_payload_t *payload );
 void midi_payload_unset_z( midi_payload_t *payload );
 void midi_payload_unset_p( midi_payload_t *payload );
 
-void midi_payload_set_buffer( midi_payload_t *payload, unsigned char *buffer , size_t *buffer_size);
+void midi_payload_set_buffer( midi_payload_t *payload, unsigned char *buffer , size_t *buffer_size, int fd );
 void midi_payload_header_dump( midi_payload_header_t *header );
 void midi_payload_pack( midi_payload_t *payload, unsigned char **buffer, size_t *buffer_size);
 void midi_payload_unpack( midi_payload_t **payload, unsigned char *buffer, size_t buffer_size);
-void midi_payload_to_commands( midi_payload_t *payload, midi_payload_data_t data_type, midi_command_t **commands, size_t *num_commands );
-void midi_command_to_payload( midi_command_t *command, midi_payload_t **payload );
+void midi_payload_to_commands( midi_payload_t *payload, midi_payload_data_t data_type, midi_command_t **commands, size_t *num_commands, int fd );
+void midi_command_to_payload( midi_command_t *command, midi_payload_t **payload, int fd );
 #endif

--- a/raveloxmidi/include/net_distribute.h
+++ b/raveloxmidi/include/net_distribute.h
@@ -21,6 +21,6 @@
 #ifndef _NET_DISTRIBUTE_H
 #define _NET_DISTRIBUTE_H
 
-void net_distribute_midi( unsigned char *packet, size_t recv_len );
+void net_distribute_midi( unsigned char *packet, size_t recv_len, int fd );
 
 #endif

--- a/raveloxmidi/src/net_distribute.c
+++ b/raveloxmidi/src/net_distribute.c
@@ -63,7 +63,7 @@ extern int errno;
 #include "raveloxmidi_alsa.h"
 
 /* Send MIDI commands to all connections */
-void net_distribute_midi( unsigned char *packet, size_t recv_len)
+void net_distribute_midi( unsigned char *packet, size_t recv_len, int fd )
 {
 	rtp_packet_t *rtp_packet = NULL;
 	unsigned char *packed_rtp_buffer = NULL;
@@ -89,8 +89,8 @@ void net_distribute_midi( unsigned char *packet, size_t recv_len)
 	// Convert the buffer into a set of commands
 	midi_payload_len = recv_len;
 	initial_midi_payload = midi_payload_create();
-	midi_payload_set_buffer( initial_midi_payload, packet, &midi_payload_len );
-	midi_payload_to_commands( initial_midi_payload, MIDI_PAYLOAD_STREAM, &midi_commands, &num_midi_commands );
+	midi_payload_set_buffer( initial_midi_payload, packet, &midi_payload_len, fd );
+	midi_payload_to_commands( initial_midi_payload, MIDI_PAYLOAD_STREAM, &midi_commands, &num_midi_commands, fd );
 	midi_payload_destroy( &initial_midi_payload );
 
 	for( midi_command_index = 0 ; midi_command_index < num_midi_commands ; midi_command_index++ )
@@ -100,7 +100,7 @@ void net_distribute_midi( unsigned char *packet, size_t recv_len)
 		size_t packed_payload_len = 0;
 
 		/* Extract a single command as a midi payload */
-		midi_command_to_payload( &(midi_commands[ midi_command_index ]), &single_midi_payload );
+		midi_command_to_payload( &(midi_commands[ midi_command_index ]), &single_midi_payload, fd );
 		if( ! single_midi_payload ) continue;
 
 		midi_command_map( &(midi_commands[ midi_command_index ]), &description, &message_type );

--- a/raveloxmidi/src/net_socket.c
+++ b/raveloxmidi/src/net_socket.c
@@ -348,7 +348,7 @@ int net_socket_read( int fd )
 #endif
 	// MIDI data on internal socket or ALSA rawmidi device
 	{
-		net_distribute_midi( read_buffer, read_buffer_size );
+		net_distribute_midi( read_buffer, read_buffer_size, fd );
 	} else {
 	// RTP MIDI inbound from remote socket
 		rtp_packet_t *rtp_packet = NULL;
@@ -366,7 +366,7 @@ int net_socket_read( int fd )
 		midi_payload_unpack( &midi_payload, rtp_packet->payload, read_buffer_size );
 
 		// Read all the commands in the packet into an array
-		midi_payload_to_commands( midi_payload, MIDI_PAYLOAD_RTP, &midi_commands, &num_midi_commands );
+		midi_payload_to_commands( midi_payload, MIDI_PAYLOAD_RTP, &midi_commands, &num_midi_commands, fd );
 
 		// Sent a FEEBACK packet back to the originating host to ack the MIDI packet
 		response = applemidi_feedback_create( rtp_packet->header.ssrc, rtp_packet->header.seq );


### PR DESCRIPTION
Currently, the running status is a single static variable. But if you have multiple connections, you need to keep a running status for each. Also, as per the MIDI spec the running status needs to be cleared for System Common Category Status messages (0xF0-0xF7) and left unchanged for RealTime Category messages (0xF8-0xFF). Here's a succinct description of the running status: [MIDI Specification: Running Status](http://midi.teragonaudio.com/tech/midispec/run.htm)