### PR TITLE
Removed unneeded getaddrinfo() as it was resulting a segfault.

### DIFF
--- a/raveloxmidi/src/utils.c
+++ b/raveloxmidi/src/utils.c
@@ -323,7 +323,6 @@ int get_sock_info( char *ip_address, int port, struct sockaddr *socket, socklen_
 	if( val )
 	{
 		logging_printf(LOGGING_WARN, "get_sock_info: Invalid address: [%s]:%d\n", ip_address, port );
-		freeaddrinfo( result );
 		return 1;
 	}
 


### PR DESCRIPTION
A fix to address Segmentation fault seen when the `getaddrinfo()` call in `get_sock_info()` fails to identify an address. When `getaddrinfo()` fails there is no need to call `getaddrinfo()`.