### PR TITLE
Fix to address correct parsing of hostname:port

### DIFF
--- a/raveloxmidi/src/remote_connection.c
+++ b/raveloxmidi/src/remote_connection.c
@@ -121,7 +121,10 @@ void remote_connect_init( void )
 			*p2='\0';
 			while( p1 < p2 )
 			{
-				if( *p1 == '[' ) break;
+				if ( *p1 == '[' ) {
+				    p1++;
+                                    break;
+                                }
 				p1++;
 			}
 
@@ -129,10 +132,7 @@ void remote_connect_init( void )
 		if( p1 == p2 )
 		{
 			p1 = remote_service_name;
-		} else {
-			*p1='\0';
-			p1++;
-		}
+		} 
 
 		if( remote_port_number == 0 )
 		{


### PR DESCRIPTION
When configured to connect to a hostname:port using:
`remote.connect = hostname:port
`
The first character of the hostname was getting truncated which then led to the lookup failure in `get_sock_info()` which resulted in a segfault (fixed by #89).
This patch attempts to fix this problem. 

Thanks for the great software!