### PR TITLE
Updated applemidi_sync_responder() to finish on CK2 reception

### DIFF
--- a/raveloxmidi/src/applemidi_sync.c
+++ b/raveloxmidi/src/applemidi_sync.c
@@ -57,6 +57,15 @@ net_response_t * applemidi_sync_responder( void *data )
 
 	net_ctx_dump( ctx );
 
+        if ( sync->count == 2 )
+	{
+                long long offset_estimate = ((sync->timestamp3 + sync->timestamp1) / 2) - sync->timestamp2;
+                current_time = time_in_microseconds();
+                local_timestamp = current_time - ctx->start;
+                logging_printf( LOGGING_DEBUG, "applemidi_sync_responder: CK2 Received. Sync Done. now=%lu start=%lu local_timestamp=%lu offset_estimate=%lu\n", current_time, ctx->start, local_timestamp, offset_estimate );
+                return NULL;
+        }
+
 	cmd = net_applemidi_cmd_create( NET_APPLEMIDI_CMD_SYNC );
 
 	if( ! cmd )


### PR DESCRIPTION
The `applemidi_sync_responder()` function was not terminating the the sync sequence on reception of CK2, leading to a CK loop (see #92), as it was returning a CK0 in response to a CK2, when acting as the sync session Responder.

This patch terminates the sync sequence on reception of a CK2 packet and returns a NULL response. It also debug logs the calculated latency offset estimate (from: https://developer.apple.com/library/archive/documentation/Audio/Conceptual/MIDINetworkDriverProtocol/MIDI/MIDI.html) 