### PR TITLE
minor fixes to documentation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -19,7 +19,7 @@ You will need to restart Avahi for those changes to be picked up.
 The autotools configure script will automatically detect the presence of ALSA libraries and will build the code for support.
 raveloxmidi uses the rawmidi interface so the snd-virmidi module must be loaded.
 
-The following steps can be taken to test everything is working:
+The following steps can be taken to test if everything is working:
 
 1. Ensure the snd-virmidi module is loaded.
 
@@ -77,7 +77,7 @@ client 20: 'Virtual Raw MIDI 1-0' [type=kernel,card=1]
 
 This shows that ```hw:1,0,0``` is port ```20:0```
 
-7. Connected the port to timidty:
+7. Connect the port to timidty:
 
 ```aconnect 20:0 128:0```
 

--- a/raveloxmidi/man/raveloxmidi.1.in
+++ b/raveloxmidi/man/raveloxmidi.1.in
@@ -56,8 +56,7 @@ The available options are:
 .TP
 .B network.bind_address
 IP address that raveloxmidi listens on. This can be an IPv4 or IPv6 address.
-.br
-Default is 0.0.0.0 ( meaning all IPv4 interfaces ). IPv6 equivalent is ::
+You can use 0.0.0.0 (meaning all IPv4 interfaces) or ::, its IPv6 equivalent.
 .br
 This \fBmust\fP be set in the configuration file for raveloxmidi to run.
 .TP


### PR DESCRIPTION
minor typos, plus clarification on network.bind_address. (There is no default, so we shouldn’t say default is 0.0.0.0)